### PR TITLE
Add 3D depth slider support (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,4 @@ Reality Boy is in no way affiliated with either of these parties
 * nop90 - Reality Boy backports and fixes.
 * danielps - Initial 3DS port and V810 dynarec.
 * Floogle - 3DS hardware renderer; many optimizations, bugfixes, and other improvements.
+* djedditt - Enhanced 3D depth slider support.

--- a/include/vb_set.h
+++ b/include/vb_set.h
@@ -16,6 +16,9 @@
 #define PAL_RG      3
 #define PAL_RBG     4
 
+#define SLIDER_3DS  0
+#define SLIDER_VB   1
+
 #define CONFIG_FILENAME "rv_config.ini"
 
 // vbkey positions
@@ -57,6 +60,7 @@ typedef struct VB_OPT {
     int   DYNAREC;
     int   FASTFORWARD;
     int   RENDERMODE; // 0 - hard only, 1 - hard + postproc, 2 - full soft
+    int   SLIDERMODE; // 0 - 3ds (positive parallax), 1 - virtual boy (full parallax)
     int   PAUSE_RIGHT; // right side of pause block on touch screen
     int   TOUCH_AX;
     int   TOUCH_AY;

--- a/source/3ds/gui_hard.c
+++ b/source/3ds/gui_hard.c
@@ -26,7 +26,7 @@ static C2D_TextBuf static_textbuf;
 static C2D_TextBuf dynamic_textbuf;
 
 static C2D_Text text_A, text_B, text_switch, text_saving, text_on, text_off,
-                text_sound_error, text_anykeyexit, text_about;
+                text_3ds, text_vbipd, text_sound_error, text_anykeyexit, text_about;
 
 static C2D_SpriteSheet sprite_sheet;
 static C2D_Sprite colour_wheel_sprite, logo_sprite;
@@ -46,6 +46,8 @@ typedef struct {
     char *str;
     float x, y, w, h;
     bool show_toggle, toggle;
+    C2D_Text *toggle_text_on;
+    C2D_Text *toggle_text_off;
     C2D_Text text;
 } Button;
 
@@ -64,8 +66,10 @@ static inline int handle_buttons(Button buttons[], int count);
     while (loop && aptMainLoop()) { \
         C3D_FrameBegin(C3D_FRAME_SYNCDRAW); \
         C2D_TargetClear(screen, 0); \
+        video_flush(eye_count); \
         C2D_SceneBegin(screen); \
-        hidScanInput();
+        C2D_Prepare(); \
+        hidScanInput(); \
 
 #define LOOP_END(buttons) \
         button = HANDLE_BUTTONS(buttons); \
@@ -112,10 +116,11 @@ static Button touchscreen_settings_buttons[] = {
 
 static void options();
 static Button options_buttons[] = {
-    {"Color filter", 16, 16, 288, 48},
-    {"Fastforward", 16, 80, 128, 48, true},
-    {"Sound", 176, 80, 128, 48, true},
-    {"Perf. info", 16, 144, 128, 48, true},
+    {"Color mode", 16, 16, 128, 48},
+    {"Slider mode", 176, 16, 128, 48, true, false, &text_vbipd, &text_3ds},
+    {"Fast forward", 16, 80, 128, 48, true, false, &text_on, &text_off},
+    {"Sound", 176, 80, 128, 48, true, false, &text_on, &text_off},
+    {"Perf. info", 16, 144, 128, 48, true, false, &text_on, &text_off},
     {"About", 176, 144, 128, 48},
     {"Back", 0, 208, 48, 32},
 };
@@ -154,9 +159,9 @@ static void first_menu() {
         C2D_SceneBegin(screenTarget);
         C2D_ViewScale(1, -1);
         C2D_ViewTranslate(0, -512);
-        C2D_SpriteSetPos(&logo_sprite, 384 / 2 - 4, 224 / 2);
+        C2D_SpriteSetPos(&logo_sprite, 384 / 2 - 2, 224 / 2);
         C2D_DrawSprite(&logo_sprite);
-        C2D_SpriteSetPos(&logo_sprite, 384 / 2 + 4, 224 / 2 + 256);
+        C2D_SpriteSetPos(&logo_sprite, 384 / 2 + 2, 224 / 2 + 256);
         C2D_DrawSprite(&logo_sprite);
         C2D_ViewReset();
         C2D_Flush();
@@ -734,29 +739,34 @@ static void colour_filter() {
 }
 
 static void options() {
-    options_buttons[1].toggle = tVBOpt.FASTFORWARD;
-    options_buttons[2].toggle = tVBOpt.SOUND;
-    options_buttons[3].toggle = tVBOpt.PERF_INFO;
+    options_buttons[1].toggle = tVBOpt.SLIDERMODE;
+    options_buttons[2].toggle = tVBOpt.FASTFORWARD;
+    options_buttons[3].toggle = tVBOpt.SOUND;
+    options_buttons[4].toggle = tVBOpt.PERF_INFO;
     LOOP_BEGIN(options_buttons);
     LOOP_END(options_buttons);
     switch (button) {
         case 0: // Colour filter
             return colour_filter();
-        case 1: // Fast forward
+        case 1: // Slider mode
+            tVBOpt.SLIDERMODE = !tVBOpt.SLIDERMODE;
+            saveFileOptions();
+            return options();
+        case 2: // Fast forward
             tVBOpt.FASTFORWARD = !tVBOpt.FASTFORWARD;
             return options();
-        case 2: // Sound
+        case 3: // Sound
             tVBOpt.SOUND = !tVBOpt.SOUND;
             if (tVBOpt.SOUND) sound_enable();
             else sound_disable();
             return options();
-        case 3: // Performance info
+        case 4: // Performance info
             tVBOpt.PERF_INFO = !tVBOpt.PERF_INFO;
             saveFileOptions();
             return options();
-        case 4: // About
+        case 5: // About
             return about();
-        case 5: // Back
+        case 6: // Back
             return main_menu();
     }
 }
@@ -817,7 +827,7 @@ static inline int handle_buttons(Button buttons[], int count) {
             strptr++;
         }
         C2D_DrawText(&buttons[i].text, C2D_AlignCenter, buttons[i].x + buttons[i].w / 2, buttons[i].y + buttons[i].h / 2 + yoff, 0, 0.7, 0.7);
-        if (buttons[i].show_toggle) C2D_DrawText(buttons[i].toggle ? &text_on : &text_off, C2D_AlignLeft, buttons[i].x, buttons[i].y, 0, 0.5, 0.5);
+        if (buttons[i].show_toggle) C2D_DrawText(buttons[i].toggle ? buttons[i].toggle_text_on : buttons[i].toggle_text_off, C2D_AlignLeft, buttons[i].x, buttons[i].y, 0, 0.5, 0.5);
     }
     if (save_thread) C2D_DrawText(&text_saving, C2D_AlignLeft, 0, 224, 0, 0.5, 0.5);
     if (ret >= 0) pressed = -1;
@@ -890,6 +900,10 @@ void guiInit() {
     C2D_TextOptimize(&text_on);
     C2D_TextParse(&text_off, static_textbuf, "Off");
     C2D_TextOptimize(&text_off);
+    C2D_TextParse(&text_3ds, static_textbuf, "Nintendo 3DS");
+    C2D_TextOptimize(&text_3ds);
+    C2D_TextParse(&text_vbipd, static_textbuf, "Virtual Boy IPD");
+    C2D_TextOptimize(&text_vbipd);
     C2D_TextParse(&text_sound_error, static_textbuf, "Error: couldn't initialize audio.\nDid you dump your DSP firmware?");
     C2D_TextOptimize(&text_sound_error);
     C2D_TextParse(&text_anykeyexit, static_textbuf, "Press any key to exit");

--- a/source/3ds/video.c
+++ b/source/3ds/video.c
@@ -19,7 +19,8 @@
 #define TOP_SCREEN_HEIGHT 240
 #define VIEWPORT_WIDTH    384
 #define VIEWPORT_HEIGHT   224
-#define MAX_DEPTH         8
+#define MAX_DEPTH         16
+#define CENTER_OFFSET     (MAX_DEPTH / 2)
 
 static inline u8 clamp127(u16 a) {
 	return a < 127 ? a : 127;
@@ -253,9 +254,16 @@ void video_render(int alt_buf) {
 
 float getDepthOffset(bool left_for_both, int eye) {
     if (left_for_both) {
-        return 0;
+        return 0.0f;
+    } else {
+        float depthOffset = 0.0f;
+        if (eye == 0) {
+            depthOffset = (CONFIG_3D_SLIDERSTATE * MAX_DEPTH) - CENTER_OFFSET;
+        } else {
+            depthOffset = (-CONFIG_3D_SLIDERSTATE * MAX_DEPTH) + CENTER_OFFSET;
+        }
+        return depthOffset;
     }
-    return (eye == 0) ? CONFIG_3D_SLIDERSTATE * MAX_DEPTH : -CONFIG_3D_SLIDERSTATE * MAX_DEPTH;
 }
 
 void video_flush(bool left_for_both) {

--- a/source/3ds/video.c
+++ b/source/3ds/video.c
@@ -252,17 +252,17 @@ void video_render(int alt_buf) {
 	video_flush(eye_count);
 }
 
-float getDepthOffset(bool left_for_both, int eye) {
+float getDepthOffset(bool left_for_both, int eye, bool full_parallax) {
     if (left_for_both) {
         return 0.0f;
+    }
+
+    float directionFactor = (eye == 0) ? 1.0f : -1.0f;
+
+    if (!full_parallax) {
+		return directionFactor * CONFIG_3D_SLIDERSTATE * (MAX_DEPTH / 2);
     } else {
-        float depthOffset = 0.0f;
-        if (eye == 0) {
-            depthOffset = (CONFIG_3D_SLIDERSTATE * MAX_DEPTH) - CENTER_OFFSET;
-        } else {
-            depthOffset = (-CONFIG_3D_SLIDERSTATE * MAX_DEPTH) + CENTER_OFFSET;
-        }
-        return depthOffset;
+        return directionFactor * (CONFIG_3D_SLIDERSTATE * MAX_DEPTH) - (directionFactor * CENTER_OFFSET);
     }
 }
 
@@ -301,7 +301,7 @@ void video_flush(bool left_for_both) {
 	int viewportY = (TOP_SCREEN_HEIGHT - VIEWPORT_HEIGHT) / 2;
 	
 	for (int eye = 0; eye < (left_for_both ? 2 : eye_count); eye++) {
-		float depthOffset = getDepthOffset(left_for_both, eye);
+		float depthOffset = getDepthOffset(left_for_both, eye, tVBOpt.SLIDERMODE);
 		C3D_RenderTargetClear(finalScreen[eye], C3D_CLEAR_ALL, 0, 0);
 		C3D_FrameDrawOn(finalScreen[eye]);
 		C3D_SetViewport(viewportY, viewportX+depthOffset, VIEWPORT_HEIGHT, VIEWPORT_WIDTH);

--- a/source/common/vb_set.c
+++ b/source/common/vb_set.c
@@ -41,6 +41,7 @@ void setDefaults(void) {
     tVBOpt.TOUCH_PADY = 128;
     tVBOpt.ABXY_MODE = 0;
     tVBOpt.TINT = 0xff0000ff;
+    tVBOpt.SLIDERMODE = SLIDER_3DS;
     tVBOpt.PERF_INFO = false;
     tVBOpt.ROM_PATH = NULL;
 
@@ -82,6 +83,8 @@ static int handler(void* user, const char* section, const char* name,
     #define MATCH(s, n) strcmp(section, s) == 0 && strcmp(name, n) == 0
     if (MATCH("vbopt", "tint")) {
         pconfig->TINT = atoi(value);
+    } else if (MATCH("vbopt", "slidermode")) {
+        pconfig->SLIDERMODE = atoi(value);
     } else if (MATCH("vbopt", "perfinfo")) {
         pconfig->PERF_INFO = atoi(value);
     } else if (MATCH("vbopt", "lastrom")) {
@@ -120,6 +123,7 @@ int saveFileOptions(void) {
 
     fprintf(f, "[vbopt]\n");
     fprintf(f, "tint=%d\n", tVBOpt.TINT);
+    fprintf(f, "slidermode=%d\n", tVBOpt.SLIDERMODE);
     fprintf(f, "perfinfo=%d\n", tVBOpt.PERF_INFO);
     fprintf(f, "lastrom=%s\n", tVBOpt.ROM_PATH ? tVBOpt.ROM_PATH : "");
     fprintf(f, "abxy=%d\n", tVBOpt.ABXY_MODE);


### PR DESCRIPTION
This change allows for scaling the 3D effect with the 3D depth slider from full negative to full positive parallax, while ensuring graphics stay on screen at the maximum settings.