### PR TITLE
Add option to toggle shoulder buttons

### DIFF
--- a/include/vb_set.h
+++ b/include/vb_set.h
@@ -71,6 +71,7 @@ typedef struct VB_OPT {
     int   TOUCH_PADX;
     int   TOUCH_PADY;
     int   ABXY_MODE; // 0: A=A B=B, 1: B=A Y=B, 2: A=B B=A, 3: B=B Y=A
+    int   ZLZR_MODE; // 0: ZL=B ZR=A, 1: ZL=A, ZR=B, 2: L=B R=A, 3: L=A R=B
     char *ROM_PATH;
     char *RAM_PATH;
     char *ROM_NAME; // Path\Name of game to open

--- a/source/3ds/gui_hard.c
+++ b/source/3ds/gui_hard.c
@@ -1034,10 +1034,14 @@ void setTouchControls(bool buttons) {
         vbkey[__builtin_ctz(KEY_B)] = tVBOpt.ABXY_MODE == 0 || tVBOpt.ABXY_MODE == 3 || tVBOpt.ABXY_MODE == 4 ? VB_KEY_B : VB_KEY_A;
         vbkey[__builtin_ctz(KEY_X)] = tVBOpt.ABXY_MODE == 0 || tVBOpt.ABXY_MODE == 3 || tVBOpt.ABXY_MODE == 5 ? VB_KEY_A : VB_KEY_B;
     }
-    vbkey[__builtin_ctz(KEY_L)] = tVBOpt.ZLZR_MODE <= 1 ? VB_KEY_L : tVBOpt.ZLZR_MODE == 2 ? VB_KEY_B : VB_KEY_A;
-    vbkey[__builtin_ctz(KEY_R)] = tVBOpt.ZLZR_MODE <= 1 ? VB_KEY_R : tVBOpt.ZLZR_MODE == 2 ? VB_KEY_A : VB_KEY_B;
-    vbkey[__builtin_ctz(KEY_ZL)] = tVBOpt.ZLZR_MODE == 0 ? VB_KEY_B : tVBOpt.ZLZR_MODE == 1 ? VB_KEY_A : VB_KEY_L;
-    vbkey[__builtin_ctz(KEY_ZR)] = tVBOpt.ZLZR_MODE == 0 ? VB_KEY_A : tVBOpt.ZLZR_MODE == 1 ? VB_KEY_B : VB_KEY_R;
+    bool new_3ds = false;
+    APT_CheckNew3DS(&new_3ds);
+    if (new_3ds) {
+        vbkey[__builtin_ctz(KEY_L)] = tVBOpt.ZLZR_MODE <= 1 ? VB_KEY_L : tVBOpt.ZLZR_MODE == 2 ? VB_KEY_B : VB_KEY_A;
+        vbkey[__builtin_ctz(KEY_R)] = tVBOpt.ZLZR_MODE <= 1 ? VB_KEY_R : tVBOpt.ZLZR_MODE == 2 ? VB_KEY_A : VB_KEY_B;
+        vbkey[__builtin_ctz(KEY_ZL)] = tVBOpt.ZLZR_MODE == 0 ? VB_KEY_B : tVBOpt.ZLZR_MODE == 1 ? VB_KEY_A : VB_KEY_L;
+        vbkey[__builtin_ctz(KEY_ZR)] = tVBOpt.ZLZR_MODE == 0 ? VB_KEY_A : tVBOpt.ZLZR_MODE == 1 ? VB_KEY_B : VB_KEY_R;
+    }
 }
 
 bool guiShouldSwitch() {

--- a/source/3ds/gui_hard.c
+++ b/source/3ds/gui_hard.c
@@ -29,9 +29,9 @@ static C3D_RenderTarget *screen;
 static C2D_TextBuf static_textbuf;
 static C2D_TextBuf dynamic_textbuf;
 
-static C2D_Text text_A, text_B, text_switch, text_saving, text_on, text_off,
-                text_toggle, text_hold, text_3ds, text_vbipd, text_left, text_right,
-                text_sound_error, text_anykeyexit, text_about;
+static C2D_Text text_A, text_B, text_btn_A, text_btn_B, text_btn_L, text_btn_R, text_switch,
+                text_saving, text_on, text_off, text_toggle, text_hold, text_3ds, text_vbipd,
+                text_left, text_right, text_sound_error, text_anykeyexit, text_about;
 
 static C2D_SpriteSheet sprite_sheet;
 static C2D_Sprite colour_wheel_sprite, logo_sprite;
@@ -456,9 +456,16 @@ static void rom_loader() {
 }
 
 static void controls() {
-    bool pressed = false;
+    bool shoulder_pressed = false;
+    bool face_pressed = false;
+    bool new_3ds = false;
+    APT_CheckNew3DS(&new_3ds);
+    const int SHOULDX = 160;
+    const int SHOULDY = 0;
+    const int SHOULDW = 128;
+    const int SHOULDH = 40;
     const int FACEX = 160;
-    const int FACEY = 80;
+    const int FACEY = new_3ds ? 92 : 80;
     const int FACEW = 128;
     const int FACEH = 80;
     const int OFFSET = 22;
@@ -467,28 +474,42 @@ static void controls() {
         touchPosition touch_pos;
         hidTouchRead(&touch_pos);
         if (hidKeysHeld() & KEY_TOUCH) {
-            if (touch_pos.px >= FACEX - FACEW/2 && touch_pos.px < FACEX + FACEW/2 && touch_pos.py >= FACEY - FACEH/2 && touch_pos.py < FACEY + FACEH/2) {
+            if (new_3ds && touch_pos.px >= SHOULDX - SHOULDW/2 && touch_pos.px < SHOULDX + SHOULDW/2 && touch_pos.py <= SHOULDH) {
                 if (hidKeysDown() & KEY_TOUCH) {
-                    pressed = true;
+                    shoulder_pressed = true;
                 }
-            } else {
-                pressed = false;
+            } else if (touch_pos.px >= FACEX - FACEW/2 && touch_pos.px < FACEX + FACEW/2 && touch_pos.py >= FACEY - FACEH/2 && touch_pos.py < FACEY + FACEH/2) {
+                if (hidKeysDown() & KEY_TOUCH) {
+                    face_pressed = true;
+                }
+            } else  {
+                shoulder_pressed = false;
+                face_pressed = false;
             }
-        } else if (pressed) {
+        } else if (shoulder_pressed) {
+            changed = true;
+            tVBOpt.ZLZR_MODE = (tVBOpt.ZLZR_MODE + 1) % 4;
+            shoulder_pressed = false;
+            setTouchControls(buttons_on_screen);
+        } else if (face_pressed) {
             changed = true;
             tVBOpt.ABXY_MODE = (tVBOpt.ABXY_MODE + 1) % 6;
-            pressed = false;
+            face_pressed = false;
             setTouchControls(buttons_on_screen);
         }
-        C2D_DrawRectSolid(FACEX - FACEW/2, FACEY - FACEH/2, 0, FACEW, FACEH, pressed ? C2D_Color32(TINT_R*0.5, TINT_G*0.5, TINT_B*0.5, 255) : C2D_Color32(TINT_R, TINT_G, TINT_B, 255));
-        C2D_DrawCircleSolid(FACEX + OFFSET, FACEY, 0, 12, C2D_Color32(0, 0, 0, 192));
-        C2D_DrawCircleSolid(FACEX - OFFSET, FACEY, 0, 12, C2D_Color32(0, 0, 0, 192));
-        C2D_DrawCircleSolid(FACEX, FACEY + OFFSET, 0, 12, C2D_Color32(0, 0, 0, 192));
-        C2D_DrawCircleSolid(FACEX, FACEY - OFFSET, 0, 12, C2D_Color32(0, 0, 0, 192));
-        C2D_DrawText(tVBOpt.ABXY_MODE == 0 || tVBOpt.ABXY_MODE == 3 || tVBOpt.ABXY_MODE == 5 ? &text_A : &text_B, C2D_AlignCenter | C2D_WithColor, FACEX, FACEY - OFFSET - 8, 0, 0.5, 0.5, C2D_Color32(255, 255, 255, 255));
-        C2D_DrawText(tVBOpt.ABXY_MODE == 0 || tVBOpt.ABXY_MODE == 3 || tVBOpt.ABXY_MODE == 4 ? &text_B : &text_A, C2D_AlignCenter | C2D_WithColor, FACEX, FACEY + OFFSET - 8, 0, 0.5, 0.5, C2D_Color32(255, 255, 255, 255));
-        C2D_DrawText(tVBOpt.ABXY_MODE < 2 || tVBOpt.ABXY_MODE == 5 ? &text_B : &text_A, C2D_AlignCenter | C2D_WithColor, FACEX - OFFSET, FACEY - 8, 0, 0.5, 0.5, C2D_Color32(255, 255, 255, 255));
-        C2D_DrawText(tVBOpt.ABXY_MODE < 2 || tVBOpt.ABXY_MODE == 4 ? &text_A : &text_B, C2D_AlignCenter | C2D_WithColor, FACEX + OFFSET, FACEY - 8, 0, 0.5, 0.5, C2D_Color32(255, 255, 255, 255));
+        if (new_3ds) {
+            C2D_DrawRectSolid(SHOULDX - SHOULDW/2, SHOULDY, 0, SHOULDW, SHOULDH, shoulder_pressed ? C2D_Color32(TINT_R*0.5, TINT_G*0.5, TINT_B*0.5, 255) : C2D_Color32(TINT_R, TINT_G, TINT_B, 255));
+            // Shifting the draw x offset by 0.5 is a workaround for a Citro2D text rendering bug; it's being done to the (3DS) L, R, A, B, X, Y buttons here
+            C2D_DrawText(tVBOpt.ZLZR_MODE <= 1 ? &text_btn_L : tVBOpt.ZLZR_MODE <= 2 ? &text_btn_B : &text_btn_A, C2D_AlignCenter, SHOULDX - OFFSET*2 - 0.5, SHOULDY + 5, 0, 1, 1);
+            C2D_DrawText(tVBOpt.ZLZR_MODE >= 2 ? &text_btn_L : tVBOpt.ZLZR_MODE == 0 ? &text_btn_B : &text_btn_A, C2D_AlignCenter, SHOULDX - OFFSET*0.75, SHOULDY + 5, 0, 1, 1);
+            C2D_DrawText(tVBOpt.ZLZR_MODE >= 2 ? &text_btn_R : tVBOpt.ZLZR_MODE == 0 ? &text_btn_A : &text_btn_B, C2D_AlignCenter, SHOULDX + OFFSET*0.75, SHOULDY + 5, 0, 1, 1);
+            C2D_DrawText(tVBOpt.ZLZR_MODE <= 1 ? &text_btn_R : tVBOpt.ZLZR_MODE <= 2 ? &text_btn_A : &text_btn_B, C2D_AlignCenter, SHOULDX + OFFSET*2 + 0.5, SHOULDY + 5, 0, 1, 1);
+        }
+        C2D_DrawRectSolid(FACEX - FACEW/2, FACEY - FACEH/2, 0, FACEW, FACEH, face_pressed ? C2D_Color32(TINT_R*0.5, TINT_G*0.5, TINT_B*0.5, 255) : C2D_Color32(TINT_R, TINT_G, TINT_B, 255));
+        C2D_DrawText(tVBOpt.ABXY_MODE == 0 || tVBOpt.ABXY_MODE == 3 || tVBOpt.ABXY_MODE == 5 ? &text_btn_A : &text_btn_B, C2D_AlignCenter, FACEX - 0.5, FACEY - OFFSET - 16, 0, 1, 1);
+        C2D_DrawText(tVBOpt.ABXY_MODE == 0 || tVBOpt.ABXY_MODE == 3 || tVBOpt.ABXY_MODE == 4 ? &text_btn_B : &text_btn_A, C2D_AlignCenter, FACEX - 0.5, FACEY + OFFSET - 16, 0, 1, 1);
+        C2D_DrawText(tVBOpt.ABXY_MODE < 2 || tVBOpt.ABXY_MODE == 5 ? &text_btn_B : &text_btn_A, C2D_AlignCenter, FACEX - OFFSET - 0.5, FACEY - 16, 0, 1, 1);
+        C2D_DrawText(tVBOpt.ABXY_MODE < 2 || tVBOpt.ABXY_MODE == 4 ? &text_btn_A : &text_btn_B, C2D_AlignCenter, FACEX + OFFSET - 0.5, FACEY - 16, 0, 1, 1);
     LOOP_END(controls_buttons);
     if (changed) saveFileOptions();
     switch (button) {
@@ -915,6 +936,14 @@ void guiInit() {
     C2D_TextOptimize(&text_A);
     C2D_TextParse(&text_B, static_textbuf, "B");
     C2D_TextOptimize(&text_B);
+    C2D_TextParse(&text_btn_A, static_textbuf, "\uE000");
+    C2D_TextOptimize(&text_btn_A);
+    C2D_TextParse(&text_btn_B, static_textbuf, "\uE001");
+    C2D_TextOptimize(&text_btn_B);
+    C2D_TextParse(&text_btn_L, static_textbuf, "\uE004");
+    C2D_TextOptimize(&text_btn_L);
+    C2D_TextParse(&text_btn_R, static_textbuf, "\uE005");
+    C2D_TextOptimize(&text_btn_R);
     C2D_TextParse(&text_switch, static_textbuf, "Switch");
     C2D_TextOptimize(&text_switch);
     C2D_TextParse(&text_saving, static_textbuf, "Saving...");
@@ -1005,6 +1034,10 @@ void setTouchControls(bool buttons) {
         vbkey[__builtin_ctz(KEY_B)] = tVBOpt.ABXY_MODE == 0 || tVBOpt.ABXY_MODE == 3 || tVBOpt.ABXY_MODE == 4 ? VB_KEY_B : VB_KEY_A;
         vbkey[__builtin_ctz(KEY_X)] = tVBOpt.ABXY_MODE == 0 || tVBOpt.ABXY_MODE == 3 || tVBOpt.ABXY_MODE == 5 ? VB_KEY_A : VB_KEY_B;
     }
+    vbkey[__builtin_ctz(KEY_L)] = tVBOpt.ZLZR_MODE <= 1 ? VB_KEY_L : tVBOpt.ZLZR_MODE == 2 ? VB_KEY_B : VB_KEY_A;
+    vbkey[__builtin_ctz(KEY_R)] = tVBOpt.ZLZR_MODE <= 1 ? VB_KEY_R : tVBOpt.ZLZR_MODE == 2 ? VB_KEY_A : VB_KEY_B;
+    vbkey[__builtin_ctz(KEY_ZL)] = tVBOpt.ZLZR_MODE == 0 ? VB_KEY_B : tVBOpt.ZLZR_MODE == 1 ? VB_KEY_A : VB_KEY_L;
+    vbkey[__builtin_ctz(KEY_ZR)] = tVBOpt.ZLZR_MODE == 0 ? VB_KEY_A : tVBOpt.ZLZR_MODE == 1 ? VB_KEY_B : VB_KEY_R;
 }
 
 bool guiShouldSwitch() {

--- a/source/common/vb_set.c
+++ b/source/common/vb_set.c
@@ -41,6 +41,7 @@ void setDefaults(void) {
     tVBOpt.TOUCH_PADX = 240;
     tVBOpt.TOUCH_PADY = 128;
     tVBOpt.ABXY_MODE = 0;
+    tVBOpt.ZLZR_MODE = 0;
     tVBOpt.TINT = 0xff0000ff;
     tVBOpt.SLIDERMODE = SLIDER_3DS;
     tVBOpt.DEFAULT_EYE = 0;
@@ -74,6 +75,8 @@ void setDefaults(void) {
 
     vbkey[__builtin_ctz(KEY_L)] = VB_KEY_L;
     vbkey[__builtin_ctz(KEY_R)] = VB_KEY_R;
+    vbkey[__builtin_ctz(KEY_ZL)] = VB_KEY_B;
+    vbkey[__builtin_ctz(KEY_ZR)] = VB_KEY_A;
 #endif
 }
 
@@ -96,6 +99,8 @@ static int handler(void* user, const char* section, const char* name,
         strcpy(pconfig->ROM_PATH, value);
     } else if (MATCH("vbopt", "abxy")) {
         pconfig->ABXY_MODE = atoi(value) % 6;
+    } else if (MATCH("vbopt", "zlzr")) {
+        pconfig->ZLZR_MODE = atoi(value) % 4;
     } else if (MATCH("touch", "ax")) {
         tVBOpt.TOUCH_AX = atoi(value);
     } else if (MATCH("touch", "ay")) {
@@ -134,6 +139,7 @@ int saveFileOptions(void) {
     fprintf(f, "perfinfo=%d\n", tVBOpt.PERF_INFO);
     fprintf(f, "lastrom=%s\n", tVBOpt.ROM_PATH ? tVBOpt.ROM_PATH : "");
     fprintf(f, "abxy=%d\n", tVBOpt.ABXY_MODE);
+    fprintf(f, "zlzr=%d\n", tVBOpt.ZLZR_MODE);
     fprintf(f, "[touch]\n");
     fprintf(f, "ax=%d\n", tVBOpt.TOUCH_AX);
     fprintf(f, "ay=%d\n", tVBOpt.TOUCH_AY);


### PR DESCRIPTION
This does what I talked about in issue #32.

It adds a new option and on-screen toggle for `tVBOpt.ZLZR_MODE`, which tracks the user's shoulder button preference. Using this setting, whichever input is currently mapped to the touch screen also gets mapped to the user's chosen shoulder buttons, which means players on New models aren't forced to use the touch screen in games which have more complicated control schemes (at least Jack Bros., Red Alarm, Teleroboxer and Virtual Bowling).

This setting has four possible values, which map to the following layouts:
<div align="center">
<table>
<tr> <th> ZLZR_MODE <th> L <th> ZL <th> ZR <th> R
<tr> <th colspan="5">D-pad on screen/shoulders
<tr> <td> 0-1 <td> L <td> D-pad Left <td> D-pad Right <td> R
<tr> <td> 2-3 <td> D-pad Left <td> L <td> R <td> D-pad Right
<tr> <th colspan="5">A and B buttons on screen/shoulders
<tr> <td> 0 <td> L <td> B <td> A <td> R
<tr> <td> 1 <td> L <td> A <td> B <td> R
<tr> <td> 2 <td> B <td> L <td> R <td> A
<tr> <td> 3 <td> A <td> L <td> R <td> B
</table>
</div>
I promise it's less complicated than it looks. I do some tricksy stuff in the menu toggle so that it jumps two options ahead when you toggle it while in D-pad mode rather than having you toggle between options that don't change the config:

```c
tVBOpt.ZLZR_MODE = (tVBOpt.ZLZR_MODE + (buttons_on_screen ? 1 : 2)) % 4;
```

# Reasons for draft status
1. [x] ~~Do you want a way to disable this option entirely on original 3DS models?~~
    **Done**

    **EDIT:** The second build below attempts to check that this is a New 3DS before enabling the shoulder button toggles, but I don't own an original 3DS (and my PC can't run Citra) so I'm not able to actually confirm that it works. If somebody with an o3DS feels like testing that build to check whether the Controls screen looks like the screenshot above or if the top section is removed as I intended, I'll update this PR with that fix.

    **EDIT2:** Confirmed via Citra Android that the New 3DS check is working and updated this PR to add it in.

2. [x] ~~`C2D_DrawText` does some kinda weird stuff with some glyphs, it feels like it doesn't leave enough padding for anti-aliasing of the text? See the way the (B) buttons look slightly clipped on each side. Not sure if this is fixable in C2D?~~
    **Fixed**

    **EDIT3:** This is an upstream bug with `C2D_AlignCenter`, using different alignments prevents this clipping from occurring (but obviously complicates the process of laying out text when the center is what you need).

    **EDIT4:** I have filed upstream issue devkitPro/citro2d#47 about this apparent oversight.

    In the meantime, I have implemented a workaround for the text rendering bug by shifting each glyph by a half pixel. Build 3 below includes this fix.

<div align="center">

Without workaround:
![image](https://github.com/skyfloogle/red-viper/assets/5259025/565e2ce4-f0f8-465b-9655-84cf2b987ea0)

With workaround:
![image](https://github.com/skyfloogle/red-viper/assets/5259025/34fdca57-bb5e-4218-b605-2432df8638fe)

</div>

# Test builds
1. [red-viper_shoulders-pr_hotfix.zip](https://github.com/skyfloogle/red-viper/files/14506299/red-viper_shoulders-pr_hotfix.zip)
2. [red-viper_shoulders-pr_old-3ds-check.zip](https://github.com/skyfloogle/red-viper/files/14509050/red-viper_shoulders-pr_old-3ds-check.zip)
3. [red-viper_shoulders-pr_old-3ds-check-citro2d-fix.zip](https://github.com/skyfloogle/red-viper/files/14511127/red-viper_shoulders-pr_old-3ds-check-citro2d-fix.zip)
