### PR TITLE
Mask register operands for shift operations

### DIFF
--- a/include/arm_emit.h
+++ b/include/arm_emit.h
@@ -408,6 +408,12 @@ static inline void new_floating_point(BYTE cond, BYTE opc1, BYTE opc2, BYTE b12,
 #define SUB_I(Rd, Rn, imm8, rot) \
     new_data_proc_imm(ARM_COND_AL, ARM_OP_SUB, 0, Rn, Rd, rot, imm8)
 
+// and Rd, imm, ror #rot
+// And immediate
+// imm8 can be rotated an even number of times
+#define AND_I(Rd, imm8, rot) \
+    new_data_proc_imm(ARM_COND_AL, ARM_OP_AND, 0, Rd, Rd, rot>>1, imm8)
+
 // orrcc Rd, imm, ror #rot
 // Or immediate with condition
 // imm8 can be rotated an even number of times

--- a/source/common/drc_core.c
+++ b/source/common/drc_core.c
@@ -944,19 +944,28 @@ static int drc_translateBlock() {
             case V810_OP_SHL: // shl reg1, reg2
                 LOAD_REG1();
                 LOAD_REG2();
-                LSLS(arm_reg2, arm_reg2, arm_reg1);
+                MOV(0, arm_reg1);
+                MOV_I(1, 0x1F, 0);
+                AND(0, 0, 1);
+                LSLS(arm_reg2, arm_reg2, 0);
                 reg2_modified = true;
                 break;
             case V810_OP_SHR: // shr reg1, reg2
                 LOAD_REG1();
                 LOAD_REG2();
-                LSRS(arm_reg2, arm_reg2, arm_reg1);
+                MOV(0, arm_reg1);
+                MOV_I(1, 0x1F, 0);
+                AND(0, 0, 1);
+                LSRS(arm_reg2, arm_reg2, 0);
                 reg2_modified = true;
                 break;
             case V810_OP_SAR: // sar reg1, reg2
                 LOAD_REG1();
                 LOAD_REG2();
-                ASRS(arm_reg2, arm_reg2, arm_reg1);
+                MOV(0, arm_reg1);
+                MOV_I(1, 0x1F, 0);
+                AND(0, 0, 1);
+                ASRS(arm_reg2, arm_reg2, 0);
                 reg2_modified = true;
                 break;
             case V810_OP_MUL: // mul reg1, reg2

--- a/source/common/drc_core.c
+++ b/source/common/drc_core.c
@@ -945,8 +945,7 @@ static int drc_translateBlock() {
                 LOAD_REG1();
                 LOAD_REG2();
                 MOV(0, arm_reg1);
-                MOV_I(1, 0x1F, 0);
-                AND(0, 0, 1);
+                AND_I(0, 0x1F, 0);
                 LSLS(arm_reg2, arm_reg2, 0);
                 reg2_modified = true;
                 break;
@@ -954,8 +953,7 @@ static int drc_translateBlock() {
                 LOAD_REG1();
                 LOAD_REG2();
                 MOV(0, arm_reg1);
-                MOV_I(1, 0x1F, 0);
-                AND(0, 0, 1);
+                AND_I(0, 0x1F, 0);
                 LSRS(arm_reg2, arm_reg2, 0);
                 reg2_modified = true;
                 break;
@@ -963,8 +961,7 @@ static int drc_translateBlock() {
                 LOAD_REG1();
                 LOAD_REG2();
                 MOV(0, arm_reg1);
-                MOV_I(1, 0x1F, 0);
-                AND(0, 0, 1);
+                AND_I(0, 0x1F, 0);
                 ASRS(arm_reg2, arm_reg2, 0);
                 reg2_modified = true;
                 break;


### PR DESCRIPTION
Register operands are masked to 0x1F prior to being applied, see http://perfectkiosk.net/stsvb.html#cpu_bitwise

This corrects that issue, thus allowing previously unplayable homebrew to run (and probably fixing some issues in commercial games as well). 