### PR TITLE
Account for HOFSTR hardware flaw in h-bias worlds

### DIFF
--- a/source/3ds/video_hard.c
+++ b/source/3ds/video_hard.c
@@ -501,7 +501,10 @@ void video_hard_render() {
 							base_u += mx;
 							base_v += my;
 							for (int y = 0; y < h; y++) {
-								s16 p = (s16)(params[y * 2 + eye] << 3) >> 3;
+								// Account for hardware flaw that uses OR rather than addition
+								// when computing the address of HOFSTR.
+								int eye_offset = !((((int)params >> 1) & 1) | eye);
+								s16 p = (s16)(params[y * 2 + eye_offset] << 3) >> 3;
 								avcur->x1 = gx;
 								avcur->y1 = gy + y + 256 * eye;
 								avcur->x2 = gx + w;


### PR DESCRIPTION
VB hardware will OR the eye "offset" with the param_base instead of adding it to compute the h-bias offset, which results in incorrect behavior if the param_base isn't word-aligned. See http://perfectkiosk.net/stsvb.html#vip_worlds_h_bias

Another selfish fix for Elevated Speed, which exploits this flaw to reduce writes to VRAM

This commit is an alternative to https://github.com/skyfloogle/red-viper/pull/43