### PR TITLE
Button input in GUI

### DIFF
--- a/source/3ds/gui_hard.c
+++ b/source/3ds/gui_hard.c
@@ -857,8 +857,8 @@ static inline int handle_buttons(Button buttons[], int count) {
             Button* temp = NULL;
             int xaxis = (bool)(kDown & KEY_RIGHT) - (bool)(kDown & KEY_LEFT);
             int yaxis = (bool)(kDown & KEY_DOWN) - (bool)(kDown & KEY_UP);
-            int selectx = (selectedButton->x + (selectedButton->w / 2)) + ((selectedButton->w / 4) * xaxis);
-            int selecty = (selectedButton->y + (selectedButton->h / 2)) + ((selectedButton->h / 4) * yaxis);
+            int selectx = (selectedButton->x + (selectedButton->w / 2)) + ((selectedButton->w / 2) * xaxis);
+            int selecty = (selectedButton->y + (selectedButton->h / 2)) + ((selectedButton->h / 2) * yaxis);
 
             for (int i = 0; i < count; i++)
             {
@@ -867,8 +867,8 @@ static inline int handle_buttons(Button buttons[], int count) {
                     continue;
 
                 // skip if button is not in the right direction
-                int buttonx = (buttons[i].x + (buttons[i].w / 2)) - ((buttons[i].w / 4) * xaxis);
-                int buttony = (buttons[i].y + (buttons[i].h / 2)) - ((buttons[i].h / 4) * yaxis);
+                int buttonx = (buttons[i].x + (buttons[i].w / 2)) - ((buttons[i].w / 2) * xaxis);
+                int buttony = (buttons[i].y + (buttons[i].h / 2)) - ((buttons[i].h / 2) * yaxis);
 
                 if (((kDown & KEY_UP)    && buttony >= selecty) ||
                     ((kDown & KEY_DOWN)  && buttony <= selecty) ||
@@ -878,7 +878,7 @@ static inline int handle_buttons(Button buttons[], int count) {
                     continue;
                 }
 
-                // use the nearest button that is within range
+                // use the nearest button that is in the right direction
                 if (temp) {
                     int tempx = (temp->x + (temp->w / 2)) - ((temp->w / 4) * xaxis);
                     int tempy = (temp->y + (temp->h / 2)) - ((temp->h / 4) * yaxis);
@@ -916,7 +916,12 @@ static inline int handle_buttons(Button buttons[], int count) {
         }
 
         // move back with the B button
-        if ((hidKeysDown() & KEY_B) && strcmp(buttons[i].str, "Back") == 0) {
+        if ((kDown & KEY_B) && strcmp(buttons[i].str, "Back") == 0) {
+            ret = i;
+        }
+
+        // select with the A button
+        if ((kDown & KEY_A) && selectedButton == &buttons[i]) {
             ret = i;
         }
     }

--- a/source/3ds/gui_hard.c
+++ b/source/3ds/gui_hard.c
@@ -855,7 +855,13 @@ static inline int handle_buttons(Button buttons[], int count) {
                 pressed = -1;
             }
         }
+
         if ((hidKeysUp() & KEY_TOUCH) && pressed == i) {
+            ret = i;
+        }
+
+        // move back with the B button
+        if ((hidKeysDown() & KEY_B) && strcmp(buttons[i].str, "Back") == 0) {
             ret = i;
         }
     }

--- a/source/3ds/gui_hard.c
+++ b/source/3ds/gui_hard.c
@@ -318,6 +318,7 @@ static void rom_loader() {
     if (scroll_bottom < scroll_top) scroll_bottom = scroll_top;
     float scroll_pos = scroll_top;
     float scroll_speed = 0;
+    int cursor = 0;
 
     if (tVBOpt.ROM_PATH && strstr(tVBOpt.ROM_PATH, path) == tVBOpt.ROM_PATH) {
         char *filename = strrchr(tVBOpt.ROM_PATH, '/');
@@ -327,6 +328,7 @@ static void rom_loader() {
                 if (strcmp(files[i], filename) == 0) {
                     int button_y = i * entry_height;
                     scroll_pos = C2D_Clamp(button_y - (240 / 2), scroll_top, scroll_bottom);
+                    cursor = i;
                 }
             }
         }
@@ -335,7 +337,6 @@ static void rom_loader() {
     buttonLock = true;
     int last_py = 0;
     int clicked_entry = -1;
-    int cursor = 0;
     bool dragging = false;
 
     LOOP_BEGIN(rom_loader_buttons);

--- a/source/3ds/gui_hard.c
+++ b/source/3ds/gui_hard.c
@@ -71,6 +71,7 @@ static inline int handle_buttons(Button buttons[], int count);
     }
 
 #define LOOP_BEGIN(buttons) \
+    selectedButton = NULL; \
     int button = -1; \
     bool loop = true; \
     while (loop && aptMainLoop()) { \
@@ -1268,7 +1269,7 @@ void guiUpdate(float total_time, float drc_time) {
 
     C2D_Flush();
 
-	C3D_ColorLogicOp(GPU_LOGICOP_COPY);
+    C3D_ColorLogicOp(GPU_LOGICOP_COPY);
 }
 
 bool guiShouldPause() {


### PR DESCRIPTION
This change allows users to navigate the GUI with the 3DS's buttons.
D-Pad: Highlight buttons
A: Press highlighted button
B: Press button labeled "Back"
X: Press button labeled "Up"
Pressing left or right on the file selector will jump up or down 10 list items.

This is a lazy/incomplete implementation because not all settings can be changed without the touch screen, such as the color selector, touch controls editor, and button config toggle switches. However I'm satisfied with just being able to navigate the file selector with button controls and I believe many other people will be too.
No button will be highlighted after changing menu screens, requiring users to press a direction once to select the first button. It's not very professional but it doesn't bother me personally.

Buttons are highlighted with the d-pad by searching for the nearest button in the pressed direction. This means it should continue to work if buttons are added or moved around in the future without needing to link buttons together manually.
This behavior can be overridden with the "buttonLock" variable for more specific control methods, as seen in the rom_loader function.

Again, this implementation can use more polish but I think it's a good start and it satisfies my needs.