### PR TITLE
Adding left 3DS DPad mode option.

### DIFF
--- a/include/vb_set.h
+++ b/include/vb_set.h
@@ -72,6 +72,7 @@ typedef struct VB_OPT {
     int   TOUCH_PADY;
     int   ABXY_MODE; // 0: A=A B=B, 1: B=A Y=B, 2: A=B B=A, 3: B=B Y=A
     int   ZLZR_MODE; // 0: ZL=B ZR=A, 1: ZL=A, ZR=B, 2: L=B R=A, 3: L=A R=B
+    int   DPAD_MODE; // Left 3DS DPAD Behavior: 0: VB LPAD, 1: VB RPAD, 2: Mirror ABXY buttons
     char *ROM_PATH;
     char *RAM_PATH;
     char *ROM_NAME; // Path\Name of game to open

--- a/source/common/vb_set.c
+++ b/source/common/vb_set.c
@@ -42,6 +42,7 @@ void setDefaults(void) {
     tVBOpt.TOUCH_PADY = 128;
     tVBOpt.ABXY_MODE = 0;
     tVBOpt.ZLZR_MODE = 0;
+    tVBOpt.DPAD_MODE = 0;
     tVBOpt.TINT = 0xff0000ff;
     tVBOpt.SLIDERMODE = SLIDER_3DS;
     tVBOpt.DEFAULT_EYE = 0;
@@ -105,6 +106,8 @@ static int handler(void* user, const char* section, const char* name,
         pconfig->ABXY_MODE = atoi(value) % 6;
     } else if (MATCH("vbopt", "zlzr")) {
         pconfig->ZLZR_MODE = atoi(value) % 4;
+    } else if (MATCH("vbopt", "dpad_mode")) {
+        pconfig->DPAD_MODE = atoi(value) % 3;
     } else if (MATCH("vbopt", "n3ds_speedup")) {
         pconfig->N3DS_SPEEDUP = atoi(value);
     } else if (MATCH("vbopt", "homepath")) {
@@ -153,6 +156,7 @@ int saveFileOptions(void) {
     fprintf(f, "lastrom=%s\n", tVBOpt.ROM_PATH ? tVBOpt.ROM_PATH : "");
     fprintf(f, "abxy=%d\n", tVBOpt.ABXY_MODE);
     fprintf(f, "zlzr=%d\n", tVBOpt.ZLZR_MODE);
+    fprintf(f, "dpad_mode=%d\n", tVBOpt.DPAD_MODE);
     fprintf(f, "n3ds_speedup=%d\n", tVBOpt.N3DS_SPEEDUP);
     fprintf(f, "homepath=%s\n", tVBOpt.HOME_PATH);
     fprintf(f, "[touch]\n");


### PR DESCRIPTION
Hi there!

In playing games like 3D Tetris and Red Alert on my old 3DS, I often found myself wanting to have 3DS hardware button/dpad access to both the VB's right dpad, and its A & B buttons, as I don't like using the touchscreen unless it's absolutely necessary.

I noticed that we have a hardware dpad on the lower left corner of the 3DS  that Red Viper simply has mirroring the circle pad/VB left dpad throughout execution, but it's pretty rare that one will be using both of those to access the VB's left dpad during regular gameplay.

Therefore, I propose opening the 3DS left dpad open to user configuration. Specifically, I propose allowing it to be configured to map to the VB's right dpad as well as its left, but also to mirror the 3DS' ABXY buttons, so that for example, if an old 3DS user wants to have one VB dpad per hand, and doesn't mind assigning the VB's A and B buttons to the 3DS' left dpad, (using the same configuration that the ABXY normally gets) they can do that with no issue. The buttons on screen can just stay there for those who want to use that.

Example usage:
- On Red Alert, having the 3DS dpad mirroring the ABXY buttons allows one VB dpad per hand on the 3DS, then the 3DS dpad can be used for VB's A & B buttons, which control speed.
- On 3D Tetris, having the 3DS dpad map to the VB's right dpad exposes all 3D rotation options to the left and right hands in hardware, without the need to switch buttons and dpads on the touchscreen.

![2024-05-05_20-19-12 460_bot](https://github.com/skyfloogle/red-viper/assets/8940345/16169d61-153d-46bd-8107-e89d5d81c6aa)

Allowable options are:
- Virtual Boy Left D-Pad
- Virtual Boy Right D-Pad
- Mirror ABXY Buttons

Tested locally on my old 3DS only.
