### PR TITLE
Adding custom control scheme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,4 +144,5 @@ Reality Boy is in no way affiliated with either of these parties
 * Floogle - 3DS hardware renderer; many optimizations, bugfixes, and other improvements.
 * djedditt - Enhanced 3D depth slider support.
 * Morintari - splash screen artwork
+* nevumx - Custom control scheme
 * All GitHub contributors

--- a/include/vb_set.h
+++ b/include/vb_set.h
@@ -75,6 +75,29 @@ typedef struct VB_OPT {
     int   DPAD_MODE; // Left 3DS DPAD Behavior: 0: VB LPAD, 1: VB RPAD, 2: Mirror ABXY buttons
     char ROM_PATH[300];
     char RAM_PATH[300];
+    int   CUSTOM_CONTROLS; // 0 - preset control scheme, 1 - custom control scheme
+    int   CUSTOM_MAPPING_DUP; // These are all 3DS buttons, each set/mapped to a VB_* value from vb_dsp.h
+    int   CUSTOM_MAPPING_DDOWN;
+    int   CUSTOM_MAPPING_DLEFT;
+    int   CUSTOM_MAPPING_DRIGHT;
+    int   CUSTOM_MAPPING_CPAD_UP;
+    int   CUSTOM_MAPPING_CPAD_DOWN;
+    int   CUSTOM_MAPPING_CPAD_LEFT;
+    int   CUSTOM_MAPPING_CPAD_RIGHT;
+    int   CUSTOM_MAPPING_CSTICK_UP;
+    int   CUSTOM_MAPPING_CSTICK_DOWN;
+    int   CUSTOM_MAPPING_CSTICK_LEFT;
+    int   CUSTOM_MAPPING_CSTICK_RIGHT;
+    int   CUSTOM_MAPPING_A;
+    int   CUSTOM_MAPPING_X;
+    int   CUSTOM_MAPPING_B;
+    int   CUSTOM_MAPPING_Y;
+    int   CUSTOM_MAPPING_START;
+    int   CUSTOM_MAPPING_SELECT;
+    int   CUSTOM_MAPPING_L;
+    int   CUSTOM_MAPPING_R;
+    int   CUSTOM_MAPPING_ZL;
+    int   CUSTOM_MAPPING_ZR;
     char *ROM_NAME; // Path\Name of game to open
     char *PROG_NAME; // Path\Name of program
     char HOME_PATH[240];
@@ -85,6 +108,7 @@ typedef struct VB_OPT {
     bool  ANAGLYPH;
 } VB_OPT;
 
+void setCustomMappingDefaults(void);
 void setDefaults(void);
 int loadFileOptions(void);
 int saveFileOptions(void);

--- a/source/3ds/gui_hard.c
+++ b/source/3ds/gui_hard.c
@@ -2130,89 +2130,82 @@ void setPresetControls(bool buttons) {
 bool guiShouldSwitch(void) {
     touchPosition touch_pos;
     hidTouchRead(&touch_pos);
-    return !tVBOpt.CUSTOM_CONTROLS && touch_pos.px >= 320 - 64 && touch_pos.py < 32;
+    return touch_pos.px >= 320 - 64 && touch_pos.py < 32;
 }
 
 void drawTouchControls(int inputs) {
-    const int pause_square_height = 70;
-    if (tVBOpt.CUSTOM_CONTROLS) {
-        C2D_DrawRectSolid(320 / 2 - pause_square_height / 2, 240 / 2 - pause_square_height / 2, 0,
-            pause_square_height * 0.4, pause_square_height, C2D_Color32(64, 64, 64, 255));
-        C2D_DrawRectSolid(320 / 2 - pause_square_height / 2 + pause_square_height * 0.6, 240 / 2 - pause_square_height / 2, 0,
-            pause_square_height * 0.4, pause_square_height, C2D_Color32(64, 64, 64, 255));
+    int col_up = TINT_50;
+    int col_down = TINT_75;
+    int col_drag = TINT_90;
+    int col_line = C2D_Color32(32, 32, 32, 255);
+    if (buttons_on_screen) {
+        float mx = (float)(tVBOpt.TOUCH_AX + tVBOpt.TOUCH_BX) / 2;
+        float my = (float)(tVBOpt.TOUCH_AY + tVBOpt.TOUCH_BY) / 2;
+        if (tVBOpt.TOUCH_AY == tVBOpt.TOUCH_BY) {
+            // edge case so we don't div0
+            C2D_DrawLine(mx, 0, col_line, mx, 240, col_line, 1, 0);
+        } else {
+            float rico = -(tVBOpt.TOUCH_BX - tVBOpt.TOUCH_AX) / (float)(tVBOpt.TOUCH_BY - tVBOpt.TOUCH_AY);
+            int oy = -rico * mx + my;
+            int ly = oy + rico * tVBOpt.PAUSE_RIGHT;
+            int ry = oy + rico * 320;
+            C2D_DrawLine(tVBOpt.PAUSE_RIGHT, ly, col_line, 320, ry, col_line, 1, 0);
+        }
     } else {
-        int col_up = TINT_50;
-        int col_down = TINT_75;
-        int col_drag = TINT_90;
-        int col_line = C2D_Color32(32, 32, 32, 255);
-        if (buttons_on_screen) {
-            float mx = (float)(tVBOpt.TOUCH_AX + tVBOpt.TOUCH_BX) / 2;
-            float my = (float)(tVBOpt.TOUCH_AY + tVBOpt.TOUCH_BY) / 2;
-            if (tVBOpt.TOUCH_AY == tVBOpt.TOUCH_BY) {
-                // edge case so we don't div0
-                C2D_DrawLine(mx, 0, col_line, mx, 240, col_line, 1, 0);
-            } else {
-                float rico = -(tVBOpt.TOUCH_BX - tVBOpt.TOUCH_AX) / (float)(tVBOpt.TOUCH_BY - tVBOpt.TOUCH_AY);
-                int oy = -rico * mx + my;
-                int ly = oy + rico * tVBOpt.PAUSE_RIGHT;
-                int ry = oy + rico * 320;
-                C2D_DrawLine(tVBOpt.PAUSE_RIGHT, ly, col_line, 320, ry, col_line, 1, 0);
-            }
-        } else {
-            C2D_DrawLine(
-                tVBOpt.PAUSE_RIGHT, tVBOpt.TOUCH_PADY - tVBOpt.TOUCH_PADX + tVBOpt.PAUSE_RIGHT, col_line,
-                320, tVBOpt.TOUCH_PADY - tVBOpt.TOUCH_PADX + 320, col_line,
-                1, 0);
-            C2D_DrawLine(
-                tVBOpt.PAUSE_RIGHT, tVBOpt.TOUCH_PADX + tVBOpt.TOUCH_PADY - tVBOpt.PAUSE_RIGHT, col_line,
-                320, tVBOpt.TOUCH_PADX + tVBOpt.TOUCH_PADY - 320, col_line,
-                1, 0);
-        }
-
         C2D_DrawLine(
-            tVBOpt.PAUSE_RIGHT, 0, C2D_Color32(64, 64, 64, 255),
-            tVBOpt.PAUSE_RIGHT, 240, C2D_Color32(64, 64, 64, 255),
+            tVBOpt.PAUSE_RIGHT, tVBOpt.TOUCH_PADY - tVBOpt.TOUCH_PADX + tVBOpt.PAUSE_RIGHT, col_line,
+            320, tVBOpt.TOUCH_PADY - tVBOpt.TOUCH_PADX + 320, col_line,
             1, 0);
-
-        bool dragging = inputs != 0;
-        if (inputs == 0) inputs = guiGetInput(false);
-
-        C2D_DrawRectSolid(tVBOpt.PAUSE_RIGHT / 2 - pause_square_height / 2, 240 / 2 - pause_square_height / 2, 0,
-            pause_square_height * 0.4, pause_square_height, C2D_Color32(64, 64, 64, 255));
-        if (replay_playing()) {
-            C2D_DrawTriangle(
-                tVBOpt.PAUSE_RIGHT / 2 - pause_square_height / 2 + pause_square_height * 0.6, 240 / 2 - pause_square_height / 2, C2D_Color32(64, 64, 64, 255),
-                tVBOpt.PAUSE_RIGHT / 2 - pause_square_height / 2 + pause_square_height * 0.6, 240 / 2 + pause_square_height / 2, C2D_Color32(64, 64, 64, 255),
-                tVBOpt.PAUSE_RIGHT / 2 - pause_square_height / 2 + pause_square_height * 0.6 + pause_square_height * 0.6, 240 / 2, C2D_Color32(64, 64, 64, 255), 0
-            );
-        } else {
-            C2D_DrawRectSolid(tVBOpt.PAUSE_RIGHT / 2 - pause_square_height / 2 + pause_square_height * 0.6, 240 / 2 - pause_square_height / 2, 0,
-                pause_square_height * 0.4, pause_square_height, C2D_Color32(64, 64, 64, 255));
-        }
-
-        if (buttons_on_screen) {
-            C2D_DrawCircleSolid(tVBOpt.TOUCH_AX, tVBOpt.TOUCH_AY, 0, 24, inputs & VB_KEY_A ? (dragging ? col_drag : col_down) : col_up);
-            C2D_DrawCircleSolid(tVBOpt.TOUCH_BX, tVBOpt.TOUCH_BY, 0, 24, inputs & VB_KEY_B ? (dragging ? col_drag : col_down) : col_up);
-            C2D_DrawText(&text_A, C2D_AlignCenter, tVBOpt.TOUCH_AX, tVBOpt.TOUCH_AY - 12, 0, 0.7, 0.7);
-            C2D_DrawText(&text_B, C2D_AlignCenter, tVBOpt.TOUCH_BX, tVBOpt.TOUCH_BY - 12, 0, 0.7, 0.7);
-        } else {
-            C2D_DrawRectSolid(tVBOpt.TOUCH_PADX - 16, tVBOpt.TOUCH_PADY - 48, 0, 16*2, 48*2, inputs & VB_KEY_A ? col_drag : col_up);
-            C2D_DrawRectSolid(tVBOpt.TOUCH_PADX - 48, tVBOpt.TOUCH_PADY - 16, 0, 48*2, 16*2, inputs & VB_KEY_A ? col_drag : col_up);
-            if (!dragging) {
-                if (inputs & VB_RPAD_L)
-                    C2D_DrawRectSolid(tVBOpt.TOUCH_PADX - 48, tVBOpt.TOUCH_PADY - 16, 0, 16*2, 16*2, col_down);
-                if (inputs & VB_RPAD_R)
-                    C2D_DrawRectSolid(tVBOpt.TOUCH_PADX + 16, tVBOpt.TOUCH_PADY - 16, 0, 16*2, 16*2, col_down);
-                if (inputs & VB_RPAD_U)
-                    C2D_DrawRectSolid(tVBOpt.TOUCH_PADX - 16, tVBOpt.TOUCH_PADY - 48, 0, 16*2, 16*2, col_down);
-                if (inputs & VB_RPAD_D)
-                    C2D_DrawRectSolid(tVBOpt.TOUCH_PADX - 16, tVBOpt.TOUCH_PADY + 16, 0, 16*2, 16*2, col_down);
-            }
-        }
-
-        C2D_DrawRectSolid(320 - 64, 0, 0, 64, 32, TINT_50);
-        C2D_DrawText(&text_switch, C2D_AlignCenter, 320 - 32, 6, 0, 0.7, 0.7);
+        C2D_DrawLine(
+            tVBOpt.PAUSE_RIGHT, tVBOpt.TOUCH_PADX + tVBOpt.TOUCH_PADY - tVBOpt.PAUSE_RIGHT, col_line,
+            320, tVBOpt.TOUCH_PADX + tVBOpt.TOUCH_PADY - 320, col_line,
+            1, 0);
     }
+
+    C2D_DrawLine(
+        tVBOpt.PAUSE_RIGHT, 0, C2D_Color32(64, 64, 64, 255),
+        tVBOpt.PAUSE_RIGHT, 240, C2D_Color32(64, 64, 64, 255),
+        1, 0);
+
+    bool dragging = inputs != 0;
+    if (inputs == 0) inputs = guiGetInput(false);
+
+    int pause_square_height = 70;
+    C2D_DrawRectSolid(tVBOpt.PAUSE_RIGHT / 2 - pause_square_height / 2, 240 / 2 - pause_square_height / 2, 0,
+        pause_square_height * 0.4, pause_square_height, C2D_Color32(64, 64, 64, 255));
+    if (replay_playing()) {
+        C2D_DrawTriangle(
+            tVBOpt.PAUSE_RIGHT / 2 - pause_square_height / 2 + pause_square_height * 0.6, 240 / 2 - pause_square_height / 2, C2D_Color32(64, 64, 64, 255),
+            tVBOpt.PAUSE_RIGHT / 2 - pause_square_height / 2 + pause_square_height * 0.6, 240 / 2 + pause_square_height / 2, C2D_Color32(64, 64, 64, 255),
+            tVBOpt.PAUSE_RIGHT / 2 - pause_square_height / 2 + pause_square_height * 0.6 + pause_square_height * 0.6, 240 / 2, C2D_Color32(64, 64, 64, 255), 0
+        );
+    } else {
+        C2D_DrawRectSolid(tVBOpt.PAUSE_RIGHT / 2 - pause_square_height / 2 + pause_square_height * 0.6, 240 / 2 - pause_square_height / 2, 0,
+            pause_square_height * 0.4, pause_square_height, C2D_Color32(64, 64, 64, 255));
+    }
+
+    if (buttons_on_screen) {
+        C2D_DrawCircleSolid(tVBOpt.TOUCH_AX, tVBOpt.TOUCH_AY, 0, 24, inputs & VB_KEY_A ? (dragging ? col_drag : col_down) : col_up);
+        C2D_DrawCircleSolid(tVBOpt.TOUCH_BX, tVBOpt.TOUCH_BY, 0, 24, inputs & VB_KEY_B ? (dragging ? col_drag : col_down) : col_up);
+        C2D_DrawText(&text_A, C2D_AlignCenter, tVBOpt.TOUCH_AX, tVBOpt.TOUCH_AY - 12, 0, 0.7, 0.7);
+        C2D_DrawText(&text_B, C2D_AlignCenter, tVBOpt.TOUCH_BX, tVBOpt.TOUCH_BY - 12, 0, 0.7, 0.7);
+    } else {
+        C2D_DrawRectSolid(tVBOpt.TOUCH_PADX - 16, tVBOpt.TOUCH_PADY - 48, 0, 16*2, 48*2, inputs & VB_KEY_A ? col_drag : col_up);
+        C2D_DrawRectSolid(tVBOpt.TOUCH_PADX - 48, tVBOpt.TOUCH_PADY - 16, 0, 48*2, 16*2, inputs & VB_KEY_A ? col_drag : col_up);
+        if (!dragging) {
+            if (inputs & VB_RPAD_L)
+                C2D_DrawRectSolid(tVBOpt.TOUCH_PADX - 48, tVBOpt.TOUCH_PADY - 16, 0, 16*2, 16*2, col_down);
+            if (inputs & VB_RPAD_R)
+                C2D_DrawRectSolid(tVBOpt.TOUCH_PADX + 16, tVBOpt.TOUCH_PADY - 16, 0, 16*2, 16*2, col_down);
+            if (inputs & VB_RPAD_U)
+                C2D_DrawRectSolid(tVBOpt.TOUCH_PADX - 16, tVBOpt.TOUCH_PADY - 48, 0, 16*2, 16*2, col_down);
+            if (inputs & VB_RPAD_D)
+                C2D_DrawRectSolid(tVBOpt.TOUCH_PADX - 16, tVBOpt.TOUCH_PADY + 16, 0, 16*2, 16*2, col_down);
+        }
+    }
+
+    C2D_DrawRectSolid(320 - 64, 0, 0, 64, 32, TINT_50);
+    C2D_DrawText(&text_switch, C2D_AlignCenter, 320 - 32, 6, 0, 0.7, 0.7);
 }
 
 void guiUpdate(float total_time, float drc_time) {
@@ -2290,7 +2283,7 @@ void guiUpdate(float total_time, float drc_time) {
 bool guiShouldPause(void) {
     touchPosition touch_pos;
     hidTouchRead(&touch_pos);
-    return ((touch_pos.px < tVBOpt.PAUSE_RIGHT || tVBOpt.CUSTOM_CONTROLS) && (touch_pos.px >= 32 || (touch_pos.py > (old_2ds ? 0 : 32) && touch_pos.py < 240-32))) && backlightEnabled;
+    return (touch_pos.px < tVBOpt.PAUSE_RIGHT && (touch_pos.px >= 32 || (touch_pos.py > (old_2ds ? 0 : 32) && touch_pos.py < 240-32))) && backlightEnabled;
 }
 
 int guiGetInput(bool ingame) {

--- a/source/common/vb_set.c
+++ b/source/common/vb_set.c
@@ -13,6 +13,40 @@
 VB_OPT  tVBOpt;
 int     vbkey[32] = {0};
 
+void setCustomMappingDefaults(void) {
+    bool new_3ds = false;
+    APT_CheckNew3DS(&new_3ds);
+    if (new_3ds) { // Since the new 3ds has a c-stick, both the Circle pad and DPad can map to the VB's L-DPad by default.
+        tVBOpt.CUSTOM_MAPPING_DUP      = VB_LPAD_U;
+        tVBOpt.CUSTOM_MAPPING_DDOWN    = VB_LPAD_D;
+        tVBOpt.CUSTOM_MAPPING_DLEFT    = VB_LPAD_L;
+        tVBOpt.CUSTOM_MAPPING_DRIGHT   = VB_LPAD_R;
+    } else { // Since the old 3ds doesn't have a c-stick, it should have a hardware mapping to the VB's R-DPad by default.
+        tVBOpt.CUSTOM_MAPPING_DUP      = VB_RPAD_U;
+        tVBOpt.CUSTOM_MAPPING_DDOWN    = VB_RPAD_D;
+        tVBOpt.CUSTOM_MAPPING_DLEFT    = VB_RPAD_L;
+        tVBOpt.CUSTOM_MAPPING_DRIGHT   = VB_RPAD_R;
+    }
+    tVBOpt.CUSTOM_MAPPING_CPAD_UP      = VB_LPAD_U;
+    tVBOpt.CUSTOM_MAPPING_CPAD_DOWN    = VB_LPAD_D;
+    tVBOpt.CUSTOM_MAPPING_CPAD_LEFT    = VB_LPAD_L;
+    tVBOpt.CUSTOM_MAPPING_CPAD_RIGHT   = VB_LPAD_R;
+    tVBOpt.CUSTOM_MAPPING_CSTICK_UP    = VB_RPAD_U;
+    tVBOpt.CUSTOM_MAPPING_CSTICK_DOWN  = VB_RPAD_D;
+    tVBOpt.CUSTOM_MAPPING_CSTICK_LEFT  = VB_RPAD_L;
+    tVBOpt.CUSTOM_MAPPING_CSTICK_RIGHT = VB_RPAD_R;
+    tVBOpt.CUSTOM_MAPPING_A            = VB_KEY_A;
+    tVBOpt.CUSTOM_MAPPING_X            = VB_KEY_A;
+    tVBOpt.CUSTOM_MAPPING_B            = VB_KEY_B;
+    tVBOpt.CUSTOM_MAPPING_Y            = VB_KEY_B;
+    tVBOpt.CUSTOM_MAPPING_START        = VB_KEY_START;
+    tVBOpt.CUSTOM_MAPPING_SELECT       = VB_KEY_SELECT;
+    tVBOpt.CUSTOM_MAPPING_L            = VB_KEY_L;
+    tVBOpt.CUSTOM_MAPPING_R            = VB_KEY_R;
+    tVBOpt.CUSTOM_MAPPING_ZL           = VB_KEY_B;
+    tVBOpt.CUSTOM_MAPPING_ZR           = VB_KEY_A;
+}
+
 void setDefaults(void) {
     // Set up the Defaults
     tVBOpt.MAXCYCLES = 400;
@@ -43,6 +77,8 @@ void setDefaults(void) {
     tVBOpt.ABXY_MODE = 0;
     tVBOpt.ZLZR_MODE = 0;
     tVBOpt.DPAD_MODE = 0;
+    tVBOpt.CUSTOM_CONTROLS = 0;
+    setCustomMappingDefaults();
     tVBOpt.TINT = 0xff0000ff;
     tVBOpt.SLIDERMODE = SLIDER_3DS;
     tVBOpt.DEFAULT_EYE = 0;
@@ -107,6 +143,52 @@ static int handler(void* user, const char* section, const char* name,
         pconfig->ZLZR_MODE = atoi(value) % 4;
     } else if (MATCH("vbopt", "dpad_mode")) {
         pconfig->DPAD_MODE = atoi(value) % 3;
+    } else if (MATCH("vbopt", "custom_controls")) {
+        pconfig->CUSTOM_CONTROLS = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_dup")) {
+        pconfig->CUSTOM_MAPPING_DUP = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_ddown")) {
+        pconfig->CUSTOM_MAPPING_DDOWN = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_dleft")) {
+        pconfig->CUSTOM_MAPPING_DLEFT = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_dright")) {
+        pconfig->CUSTOM_MAPPING_DRIGHT = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_cpad_up")) {
+        pconfig->CUSTOM_MAPPING_CPAD_UP = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_cpad_down")) {
+        pconfig->CUSTOM_MAPPING_CPAD_DOWN = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_cpad_left")) {
+        pconfig->CUSTOM_MAPPING_CPAD_LEFT = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_cpad_right")) {
+        pconfig->CUSTOM_MAPPING_CPAD_RIGHT = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_cstick_up")) {
+        pconfig->CUSTOM_MAPPING_CSTICK_UP = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_cstick_down")) {
+        pconfig->CUSTOM_MAPPING_CSTICK_DOWN = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_cstick_left")) {
+        pconfig->CUSTOM_MAPPING_CSTICK_LEFT = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_cstick_right")) {
+        pconfig->CUSTOM_MAPPING_CSTICK_RIGHT = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_a")) {
+        pconfig->CUSTOM_MAPPING_A = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_x")) {
+        pconfig->CUSTOM_MAPPING_X = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_b")) {
+        pconfig->CUSTOM_MAPPING_B = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_y")) {
+        pconfig->CUSTOM_MAPPING_Y = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_start")) {
+        pconfig->CUSTOM_MAPPING_START = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_select")) {
+        pconfig->CUSTOM_MAPPING_SELECT = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_l")) {
+        pconfig->CUSTOM_MAPPING_L = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_r")) {
+        pconfig->CUSTOM_MAPPING_R = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_zl")) {
+        pconfig->CUSTOM_MAPPING_ZL = atoi(value);
+    } else if (MATCH("vbopt", "custom_mapping_zr")) {
+        pconfig->CUSTOM_MAPPING_ZR = atoi(value);
     } else if (MATCH("vbopt", "n3ds_speedup")) {
         pconfig->N3DS_SPEEDUP = atoi(value);
     } else if (MATCH("vbopt", "homepath")) {
@@ -156,6 +238,29 @@ int saveFileOptions(void) {
     fprintf(f, "abxy=%d\n", tVBOpt.ABXY_MODE);
     fprintf(f, "zlzr=%d\n", tVBOpt.ZLZR_MODE);
     fprintf(f, "dpad_mode=%d\n", tVBOpt.DPAD_MODE);
+    fprintf(f, "custom_controls=%d\n", tVBOpt.CUSTOM_CONTROLS);
+    fprintf(f, "custom_mapping_dup=%d\n", tVBOpt.CUSTOM_MAPPING_DUP);
+    fprintf(f, "custom_mapping_ddown=%d\n", tVBOpt.CUSTOM_MAPPING_DDOWN);
+    fprintf(f, "custom_mapping_dleft=%d\n", tVBOpt.CUSTOM_MAPPING_DLEFT);
+    fprintf(f, "custom_mapping_dright=%d\n", tVBOpt.CUSTOM_MAPPING_DRIGHT);
+    fprintf(f, "custom_mapping_cpad_up=%d\n", tVBOpt.CUSTOM_MAPPING_CPAD_UP);
+    fprintf(f, "custom_mapping_cpad_down=%d\n", tVBOpt.CUSTOM_MAPPING_CPAD_DOWN);
+    fprintf(f, "custom_mapping_cpad_left=%d\n", tVBOpt.CUSTOM_MAPPING_CPAD_LEFT);
+    fprintf(f, "custom_mapping_cpad_right=%d\n", tVBOpt.CUSTOM_MAPPING_CPAD_RIGHT);
+    fprintf(f, "custom_mapping_cstick_up=%d\n", tVBOpt.CUSTOM_MAPPING_CSTICK_UP);
+    fprintf(f, "custom_mapping_cstick_down=%d\n", tVBOpt.CUSTOM_MAPPING_CSTICK_DOWN);
+    fprintf(f, "custom_mapping_cstick_left=%d\n", tVBOpt.CUSTOM_MAPPING_CSTICK_LEFT);
+    fprintf(f, "custom_mapping_cstick_right=%d\n", tVBOpt.CUSTOM_MAPPING_CSTICK_RIGHT);
+    fprintf(f, "custom_mapping_a=%d\n", tVBOpt.CUSTOM_MAPPING_A);
+    fprintf(f, "custom_mapping_x=%d\n", tVBOpt.CUSTOM_MAPPING_X);
+    fprintf(f, "custom_mapping_b=%d\n", tVBOpt.CUSTOM_MAPPING_B);
+    fprintf(f, "custom_mapping_y=%d\n", tVBOpt.CUSTOM_MAPPING_Y);
+    fprintf(f, "custom_mapping_start=%d\n", tVBOpt.CUSTOM_MAPPING_START);
+    fprintf(f, "custom_mapping_select=%d\n", tVBOpt.CUSTOM_MAPPING_SELECT);
+    fprintf(f, "custom_mapping_l=%d\n", tVBOpt.CUSTOM_MAPPING_L);
+    fprintf(f, "custom_mapping_r=%d\n", tVBOpt.CUSTOM_MAPPING_R);
+    fprintf(f, "custom_mapping_zl=%d\n", tVBOpt.CUSTOM_MAPPING_ZL);
+    fprintf(f, "custom_mapping_zr=%d\n", tVBOpt.CUSTOM_MAPPING_ZR);
     fprintf(f, "n3ds_speedup=%d\n", tVBOpt.N3DS_SPEEDUP);
     fprintf(f, "homepath=%s\n", tVBOpt.HOME_PATH);
     fprintf(f, "[touch]\n");


### PR DESCRIPTION
After much deliberation, (https://github.com/skyfloogle/red-viper/pull/65) I present the completely customizable hardware button scheme! It starts in the "Controls" menu, where you can select either the "Preset" scheme,
![2024-05-22_18-54-26 654_bot](https://github.com/skyfloogle/red-viper/assets/8940345/532540dc-415f-40ff-a042-7433a7bc6ce6)
And selecting "Configure Scheme" will take you to the old "Controls" menu, as before,
![2024-05-05_20-19-12 460_bot](https://github.com/skyfloogle/red-viper/assets/8940345/16169d61-153d-46bd-8107-e89d5d81c6aa)
BUT, selecting the "Custom" control scheme
![2024-05-22_18-54-35 364_bot](https://github.com/skyfloogle/red-viper/assets/8940345/c6cbede3-e2cd-4eb8-9a25-3632faf2622c)
And selecting "Configure Scheme" will take you to the new-and-improved, completely customizable 3DS-to-VB hardware button mapping screen, which looks like this on new 3DS:
![2024-05-22_18-57-10 335_bot](https://github.com/skyfloogle/red-viper/assets/8940345/f852d063-6d9f-4c3a-b858-c447378471a3)
and like this on the old 3DS:
![2024-05-22_18-57-41 272_bot](https://github.com/skyfloogle/red-viper/assets/8940345/3166a475-9166-486f-98fd-2474ac311e48)
Which shows you at a glance what all the 3DS-to-VB button mappings are, and then selecting one of those mapping buttons takes you to the VB button assignment screen that looks like this:
![2024-05-22_18-55-19 791_bot](https://github.com/skyfloogle/red-viper/assets/8940345/043480ef-644c-4c0c-a0de-ff4c37ff2ee1)
Which tells you what 3DS button you are currently mapping, and what VB button it is currently mapped to, and lets you map it to any other VB button! Enjoy!

**NOTE!!!** I have only tested this on an OLD 3DS! It needs to be tested on a NEW 3DS before merging please!