### PR TITLE
Convert Shaders to a Single Binary

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "source/common/inih"]
 	path = source/common/inih
 	url = https://github.com/benhoyt/inih.git
+[submodule "source/3ds/yattlib-3d"]
+	path = source/3ds/yattlib-3d
+	url = https://github.com/Wyatt-James/yattlib-3d

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ include $(DEVKITARM)/3ds_rules
 #---------------------------------------------------------------------------------
 TARGET		:=	$(notdir $(CURDIR))
 BUILD		:=	build
-SOURCES		:=	source/common source/arm source/3ds source/common/inih
+SOURCES		:=	source/common source/arm source/3ds source/common/inih source/3ds/yattlib-3d/src
 DATA		:=	data
-INCLUDES	:=	include source/common/inih
+INCLUDES	:=	include source/common/inih source/3ds/yattlib-3d/include
 GRAPHICS	:=	gfx gfx/maps
 GFXBUILD	:=	$(BUILD)
 ROMFS		:=	romfs

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ additional dependencies:
 
 After cloning the repository, fetch the last dependencies:
 ```bash
+> git submodule init
 > git submodule update
 ```
 

--- a/include/vb_dsp.h
+++ b/include/vb_dsp.h
@@ -161,7 +161,6 @@ extern bool tileVisible[2048];
 extern int blankTile;
 
 #ifdef __3DS__
-extern shaderProgram_s sFinal;
 
 // video_hard
 extern C3D_Tex screenTexHard[2];

--- a/source/3ds/affine.g.pica
+++ b/source/3ds/affine.g.pica
@@ -15,8 +15,8 @@
 .out outtc1 texcoord1
 .out outtc2 texcoord2
 
-.entry gmain
-.proc gmain
+.entry gmain_affine
+.proc gmain_affine
     ; r0: position
     ; r1: texcoord intermediate
     ; r2: texcoord final

--- a/source/3ds/affine.v.pica
+++ b/source/3ds/affine.v.pica
@@ -8,8 +8,8 @@
 .out outtc0 dummy ; uv's twice
 .out outmat dummy
 
-.entry vmain
-.proc vmain
+.entry vmain_affine
+.proc vmain_affine
     ; position: 0..size -> -1..1
     mov r0, const1.xyxy
     mad r0.xyzw, r0.xyxy, v0.xyzw, const1.wwww

--- a/source/3ds/char.g.pica
+++ b/source/3ds/char.g.pica
@@ -17,8 +17,8 @@
 .out outtc2 texcoord2
 .out outcol color
 
-.entry gmain
-.proc gmain
+.entry gmain_char
+.proc gmain_char
     ; load palette index
     mova a0.x, v1.z
 

--- a/source/3ds/char.v.pica
+++ b/source/3ds/char.v.pica
@@ -18,8 +18,8 @@
 .out outtc0 dummy
 .out outpos2 dummy
 
-.entry vmain
-.proc vmain
+.entry vmain_char
+.proc vmain_char
     ; flips
     mova a0.x, v1.w
     ; position: 0..size -> -1..1

--- a/source/3ds/final.g.pica
+++ b/source/3ds/final.g.pica
@@ -19,8 +19,8 @@
 .out coltc texcoord2
 .out vcol color
 
-.entry gmain
-.proc gmain
+.entry gmain_final
+.proc gmain_final
     ; z=-1 and w=1 are necessary for position output
     mov r0, const1
     mul r4, rad255, v2

--- a/source/3ds/final.v.pica
+++ b/source/3ds/final.v.pica
@@ -8,8 +8,8 @@
 
 ; basic passthrough, no transforming at all
 
-.entry vmain
-.proc vmain
+.entry vmain_final
+.proc vmain_final
     mov outpos, v0
     mov outtex, v1
     mov outcol, v2

--- a/source/3ds/n3ds_shader.shlist
+++ b/source/3ds/n3ds_shader.shlist
@@ -1,0 +1,6 @@
+affine.g.pica
+affine.v.pica
+char.g.pica
+char.v.pica
+final.g.pica
+final.v.pica

--- a/source/3ds/n3ds_shaders.c
+++ b/source/3ds/n3ds_shaders.c
@@ -1,0 +1,66 @@
+#include "n3ds_shaders.h"
+
+#include <stdio.h>
+#include <3ds.h>
+
+#include <yatt_shader_utils.h>
+#include <yatt_error.h>
+
+#include "n3ds_shader_shbin.h" // u8 n3ds_shader_shbin_end[], u8 n3ds_shader_shbin[], u32 n3ds_shader_shbin_size;
+
+#define ARRAY_COUNT(arr_) (size_t) (sizeof(arr_) / sizeof(arr_[0]))
+
+// Must match linking order of shlist file
+enum {
+   DVLE_AFFINE_G = 0,
+   DVLE_AFFINE_V,
+   DVLE_CHAR_G,
+   DVLE_CHAR_V,
+   DVLE_FINAL_G,
+   DVLE_FINAL_V,
+};
+
+struct n3ds_uniform_locations uLoc;
+shaderProgram_s sAffine, sChar, sFinal;
+
+static YATT_ShaderBinary shader_binary = { n3ds_shader_shbin, &n3ds_shader_shbin_size, NULL };
+
+static YATT_ShaderProgram shader_programs[] = {
+    { &shader_binary, &sAffine, DVLE_AFFINE_G, DVLE_AFFINE_V, .gsh_stride = 3 },
+    { &shader_binary, &sChar,   DVLE_CHAR_G,   DVLE_CHAR_V,   .gsh_stride = 0 },
+    { &shader_binary, &sFinal,  DVLE_FINAL_G,  DVLE_FINAL_V,  .gsh_stride = 3 },
+};
+
+static YATT_ShaderUniform uniforms[] = {
+    { .name = "posscale",       .loc_pointer = &uLoc.posscale       },
+    { .name = "pal1tex",        .loc_pointer = &uLoc.pal1tex        },
+    { .name = "pal2tex",        .loc_pointer = &uLoc.pal2tex        },
+    { .name = "pal3col",        .loc_pointer = &uLoc.pal3col        },
+    { .name = "offset",         .loc_pointer = &uLoc.offset         },
+    { .name = "bgmap_offsets",  .loc_pointer = &uLoc.bgmap_offsets  },
+    { .name = "shading_offset", .loc_pointer = &uLoc.shading_offset },
+};
+
+void n3ds_shaders_init(void)
+{
+    static bool initialized = false;
+
+    if (initialized)
+        return;
+
+    initialized = true;
+
+    yatt_shaders_enable_printing(true);
+    yatt_shaders_enable_printing(stderr);
+    
+    if (yatt_init_shader_binaries(&shader_binary, 1) != YATT_OK)
+        svcBreak(USERBREAK_PANIC);
+
+    if (yatt_init_shader_programs(shader_programs, ARRAY_COUNT(shader_programs)) != YATT_OK)
+        svcBreak(USERBREAK_PANIC);
+    
+    if (yatt_parse_shader_uniforms(uniforms, shader_programs, ARRAY_COUNT(uniforms), ARRAY_COUNT(shader_programs)) != YATT_OK)
+        svcBreak(USERBREAK_PANIC);
+
+    yatt_print_shader_uniforms(uniforms, ARRAY_COUNT(uniforms));
+}

--- a/source/3ds/n3ds_shaders.h
+++ b/source/3ds/n3ds_shaders.h
@@ -1,0 +1,19 @@
+#ifndef N3DS_SHADERS_H
+#define N3DS_SHADERS_H
+
+#include <3ds/gpu/shaderProgram.h>
+
+struct n3ds_uniform_locations {
+    int posscale,
+        pal1tex, pal2tex, pal3col,
+        offset,
+        bgmap_offsets,
+        shading_offset;
+};
+
+extern struct n3ds_uniform_locations uLoc;
+extern shaderProgram_s sAffine, sChar, sFinal;
+
+void n3ds_shaders_init(void);
+
+#endif

--- a/source/3ds/video.c
+++ b/source/3ds/video.c
@@ -17,7 +17,7 @@
 #include "periodic.h"
 #include "cpp.h"
 
-#include "final_shbin.h"
+#include "n3ds_shaders.h"
 
 #define TOP_SCREEN_WIDTH  400
 #define TOP_SCREEN_HEIGHT 240
@@ -126,11 +126,6 @@ u8 brightness_lut[256];
 
 int eye_count = 2;
 
-DVLB_s *sFinal_dvlb;
-shaderProgram_s sFinal;
-
-int uLoc_shading_offset;
-
 static int get_colour(int id, int brt_reg) {
 	if (id == 0) {
 		return tVBOpt.MULTICOL && !tVBOpt.ANAGLYPH ? tVBOpt.MTINT[tVBOpt.MULTIID][0] : 0;
@@ -165,12 +160,7 @@ void video_init(void) {
 
     gfxSet3D(true);
 
-	sFinal_dvlb = DVLB_ParseFile((u32 *)final_shbin, final_shbin_size);
-	shaderProgramInit(&sFinal);
-	shaderProgramSetVsh(&sFinal, &sFinal_dvlb->DVLE[0]);
-	shaderProgramSetGsh(&sFinal, &sFinal_dvlb->DVLE[1], 3);
-
-	uLoc_shading_offset = shaderInstanceGetUniformLocation(sFinal.geometryShader, "shading_offset");
+	n3ds_shaders_init();
 
 	coltable_vbuf = linearAlloc(4 * 96 * 2);
 	final_vbuf = linearAlloc(sizeof(float) * 4 * 2 * 96 * 2);
@@ -465,7 +455,7 @@ void video_flush(bool default_for_both) {
 		C3D_RenderTargetClear(target, C3D_CLEAR_ALL, 0, 0);
 		C3D_FrameDrawOn(target);
 		C3D_SetViewport(viewportY, viewportX+depthOffset, VIEWPORT_HEIGHT, VIEWPORT_WIDTH);
-		C3D_FVUnifSet(GPU_GEOMETRY_SHADER, uLoc_shading_offset, (src_eye ? 0.5 : 0) + 1/256.0, 0, 0, 0);
+		C3D_FVUnifSet(GPU_GEOMETRY_SHADER, uLoc.shading_offset, (src_eye ? 0.5 : 0) + 1/256.0, 0, 0, 0);
 		C3D_DrawArrays(GPU_GEOMETRY_PRIM, src_eye*96, 96);
 	}
 	


### PR DESCRIPTION
- Shaders are now loaded as a single binary. This reduces the number of times the shader code is uploaded to the GPU; on most gameplay frames, the code will never be uploaded, though Citro2D still triggers a binary upload to and back from its own internal shader whenever the menu is used, including the performance overlay.
- Added the YattLib-3D submodule, which contains some shader utilities.